### PR TITLE
[JENKINS-30235] - Fix the project links in the "Normal search" mode

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/lucene/search/FreeTextSearch/search-results.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/lucene/search/FreeTextSearch/search-results.jelly
@@ -46,7 +46,7 @@
                             <j:forEach var="hit" items="${searchModelHits}">
                                 <li>
                                     <span style="white-space: nowrap;">
-                                        <a href="${rootURL}${hit.searchUrl}">${hit.searchName}</a>
+                                        <a href="${rootURL}/${hit.searchUrl}">${hit.searchName}</a>
                                     </span>
                                 </li>
                             </j:forEach>


### PR DESCRIPTION
The original implementation used to return broken links even for default "FOO" job located in the Jenkins root. This fix adjusts the behavior.

There are also <code>hit.searchUrl</code> usages for Lucene search engine below, but actually they use another method, which generates absolute links

@reviewbybees 
