### PR TITLE
Don't skip Run that aren't AbstractBuild

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/SearchBackend.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/SearchBackend.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.lucene.search.databackend;
 
-import hudson.model.AbstractBuild;
 import hudson.model.Job;
 import hudson.model.Run;
 
@@ -76,11 +75,8 @@ public abstract class SearchBackend<T> {
                 .andStart();
         progress.setMax(0);
         for (Run<?, ?> run : job.getBuilds()) {
-            if (run instanceof AbstractBuild) {
-                progress.setMax(progress.getMax() + 1);
-                AbstractBuild build = (AbstractBuild) run;
-                burstExecutor.add(build);
-            }
+            progress.setMax(progress.getMax() + 1);
+            burstExecutor.add(run);
         }
         try {
             burstExecutor.waitForCompletion();


### PR DESCRIPTION
@hanabishi This should fix the rebuild problems causing some builds (actually Run<?, ?>) to be skipped because they aren't AbstractBuilds
