### PR TITLE
removeBuild removes the right build by using run-specific query

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,3 @@
+mvn package;
+cp target/lucene-search.hpi ~/.jenkins/plugins/lucene-search.jpi;
+

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,14 @@
 					<forkCount>1</forkCount>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>7</source>
+					<target>7</target>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x ] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x ] Link to relevant pull requests, esp. upstream and downstream changes
- [x ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

removeBuild function in org.jenkinsci.plugins.lucene.search.databackend was using run ID to identify the old run index to be deleted. However, this is not correct. As specified by https://javadoc.jenkins-ci.org/hudson/model/Run.html, run type should always be used in conjuction with the job type. Therefore, this major error results in the wrong index to be deleted and there are missing search results.

I add a function called getRunQuery which returns the correct query for a run. Now removeBuild works as expected and will not wrongly delete the run index of another job. 

I make removeBuild to return null for now as I think it is not appropriate to return an old doc and use it when the provided field value is null. This will result in inconsistency. However, this is another issue and I will solve that in another commit.

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
