### PR TITLE
Ensure proper permission checks are performed during configuration, reindexing and searching [CVE 2022 36910]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,14 +101,14 @@
 	<repositories>
 		<repository>
 			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
+			<url>https://repo.jenkins-ci.org/public/</url>
 		</repository>
 	</repositories>
 
 	<pluginRepositories>
 		<pluginRepository>
 			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
+			<url>https://repo.jenkins-ci.org/public/</url>
 		</pluginRepository>
 	</pluginRepositories>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/Field.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/Field.java
@@ -10,6 +10,8 @@ import java.util.Map;
 
 import org.apache.commons.io.output.ByteArrayOutputStream;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public enum Field {
 
     PROJECT_NAME("j", Persist.TRUE) {
@@ -55,6 +57,9 @@ public enum Field {
     },
 
     CONSOLE("c", Persist.TRUE) {
+        @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED",
+            justification = "The offset returned by writeLogTo() can be ignored, " +
+                "since no furtehr text is written to the output stream.")
         @Override
         public String getValue(Run<?, ?> build) {
             try {

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextSearchItemImplementation.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextSearchItemImplementation.java
@@ -4,6 +4,7 @@ import hudson.model.BallColor;
 import hudson.search.SearchIndex;
 import hudson.search.SearchItem;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -13,7 +14,7 @@ public class FreeTextSearchItemImplementation extends FreeTextSearchItem {
 
     private final String projectName;
     private final boolean isShowConsole;
-    private final String[] bestFragments;
+    private final List<String> bestFragments;
     private final String url;
     private final String searchName;
 
@@ -23,9 +24,9 @@ public class FreeTextSearchItemImplementation extends FreeTextSearchItem {
         this.projectName = projectName;
         this.url = url;
         this.isShowConsole = isShowConsole;
-        this.bestFragments = new String[bestFragments.length];
+        this.bestFragments = new ArrayList<>(bestFragments.length);
         for (int i = 0; i < bestFragments.length; i++) {
-            this.bestFragments[i] = LINE_ENDINGS.matcher(bestFragments[i]).replaceAll("<br/>");
+            this.bestFragments.add(LINE_ENDINGS.matcher(bestFragments[i]).replaceAll("<br/>"));
         }
 
     }
@@ -45,7 +46,7 @@ public class FreeTextSearchItemImplementation extends FreeTextSearchItem {
     }
 
     public String[] getBestFragments() {
-        return bestFragments;
+        return bestFragments.toArray(new String[bestFragments.size()]);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/SearchResultImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/SearchResultImpl.java
@@ -9,7 +9,7 @@ public class SearchResultImpl extends ArrayList<SuggestedItem> implements Search
 
     private static final long serialVersionUID = 1L;
 
-    private final boolean hasMoreResults = false;
+    private static final boolean hasMoreResults = false;
 
     @Override
     public boolean hasMoreResults() {

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/config/SearchBackendConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/config/SearchBackendConfiguration.java
@@ -38,7 +38,7 @@ public class SearchBackendConfiguration extends GlobalConfiguration {
     private transient SearchBackendManager backendManager;
 
     private File lucenePath = new File(Jenkins.getInstance().getRootDir(), "luceneIndex");
-    private boolean useSecurity;
+    private boolean useSecurity = true;
 
     @DataBoundConstructor
     public SearchBackendConfiguration(final String lucenePath,

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/config/SearchBackendConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/config/SearchBackendConfiguration.java
@@ -49,10 +49,12 @@ public class SearchBackendConfiguration extends GlobalConfiguration {
     }
 
     public void setLucenePath(final File lucenePath) {
+        Jenkins.get().getACL().checkPermission(Jenkins.ADMINISTER);
         this.lucenePath = lucenePath;
     }
 
     public FormValidation doCheckLucenePath(@QueryParameter final String lucenePath) {
+        Jenkins.get().getACL().checkPermission(Jenkins.ADMINISTER);
         try {
             new File(lucenePath);
             return FormValidation.ok();
@@ -82,6 +84,7 @@ public class SearchBackendConfiguration extends GlobalConfiguration {
 
     @VisibleForTesting
     public void reconfigure() throws IOException {
+        Jenkins.get().getACL().checkPermission(Jenkins.ADMINISTER);
         backendManager.reconfigure(getConfig());
         save();
     }
@@ -103,6 +106,7 @@ public class SearchBackendConfiguration extends GlobalConfiguration {
     }
 
     public void setUseSecurity(boolean useSecurity) {
+        Jenkins.get().getACL().checkPermission(Jenkins.ADMINISTER);
         this.useSecurity = useSecurity;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/config/SearchBackendConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/config/SearchBackendConfiguration.java
@@ -6,10 +6,7 @@ import hudson.util.FormValidation;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -18,11 +15,6 @@ import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.jenkinsci.plugins.lucene.search.databackend.SearchBackendManager;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -56,10 +48,6 @@ public class SearchBackendConfiguration extends GlobalConfiguration {
         load();
     }
 
-    public String getLucenePath() {
-        return lucenePath.toString();
-    }
-
     public void setLucenePath(final File lucenePath) {
         this.lucenePath = lucenePath;
     }
@@ -70,25 +58,6 @@ public class SearchBackendConfiguration extends GlobalConfiguration {
             return FormValidation.ok();
         } catch (RuntimeException e) {
             return FormValidation.error(e.getMessage());
-        }
-    }
-
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    private List<String> getCollections(String baseUrl) throws IOException {
-        HttpClient httpClient = HttpClientBuilder.create().build();
-        String url = baseUrl + "/admin/cores?wt=json";
-        HttpGet get = new HttpGet(url);
-        HttpResponse response = httpClient.execute(get);
-        if (response.getStatusLine().getStatusCode() != 200) {
-            throw new IOException("Failed to GET " + url);
-        }
-        InputStream content = response.getEntity().getContent();
-        try {
-            String jsonString = IOUtils.toString(content, "UTF-8");
-            JSONObject json = JSONObject.fromObject(jsonString);
-            return new ArrayList(json.getJSONObject("status").keySet());
-        } finally {
-            IOUtils.closeQuietly(content);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/Progress.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/Progress.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.lucene.search.databackend;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class Progress {
 
     public enum ProgressState {
@@ -13,7 +15,7 @@ public class Progress {
     private transient Exception reason;
     private String reasonMessage = "";
     private int max;
-    private volatile int current;
+    private AtomicInteger current = new AtomicInteger(0);
     private String name;
 
     public void assertNoErrors() throws Exception {
@@ -29,7 +31,6 @@ public class Progress {
     public Progress(String name) {
         this.setName(name);
         startTime = System.currentTimeMillis();
-        current = 0;
         max = 0;
     }
 
@@ -78,15 +79,15 @@ public class Progress {
     }
 
     public int getCurrent() {
-        return current;
+        return current.get();
     }
 
     public void setCurrent(int current) {
-        this.current = current;
+        this.current.set(current);
     }
 
-    public synchronized void incCurrent() {
-        this.current++;
+    public void incCurrent() {
+        this.current.incrementAndGet();
     }
 
     public String getName() {

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/management/LuceneManager.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/management/LuceneManager.java
@@ -157,11 +157,47 @@ public class LuceneManager extends ManagementLink {
     }
 
     public static class JSReturnCollection {
-        public int code;
-        public String message = "";
-        public boolean running;
-        public ManagerProgress progress;
-        public int workers;
-        public boolean neverStarted;
+        private int code;
+        private String message = "";
+        private boolean running;
+        private ManagerProgress progress;
+        private int workers;
+        private boolean neverStarted;
+		public int getCode() {
+			return code;
+		}
+		public void setCode(int code) {
+			this.code = code;
+		}
+		public String getMessage() {
+			return message;
+		}
+		public void setMessage(String message) {
+			this.message = message;
+		}
+		public boolean isRunning() {
+			return running;
+		}
+		public void setRunning(boolean running) {
+			this.running = running;
+		}
+		public ManagerProgress getProgress() {
+			return progress;
+		}
+		public void setProgress(ManagerProgress progress) {
+			this.progress = progress;
+		}
+		public int getWorkers() {
+			return workers;
+		}
+		public void setWorkers(int workers) {
+			this.workers = workers;
+		}
+		public boolean isNeverStarted() {
+			return neverStarted;
+		}
+		public void setNeverStarted(boolean neverStarted) {
+			this.neverStarted = neverStarted;
+		}
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/management/LuceneManager.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/management/LuceneManager.java
@@ -46,6 +46,7 @@ public class LuceneManager extends ManagementLink {
 
     @JavaScriptMethod
     public JSReturnCollection rebuildDatabase(int workers, String jobNames, String overwrite) {
+        Jenkins.get().getACL().checkPermission(getRequiredPermission());
         JSReturnCollection statement = verifyNotInProgress();
         this.workers = workers;
         if (this.workers <= 0) {
@@ -99,6 +100,7 @@ public class LuceneManager extends ManagementLink {
 
     @JavaScriptMethod
     public JSReturnCollection abort() {
+        Jenkins.get().getACL().checkPermission(getRequiredPermission());
         JSReturnCollection statement = verifyNotInProgress();
         backendManager.abort();
         this.progress = null;
@@ -107,6 +109,7 @@ public class LuceneManager extends ManagementLink {
 
     @JavaScriptMethod
     public JSReturnCollection clean() {
+        Jenkins.get().getACL().checkPermission(getRequiredPermission());
         JSReturnCollection statement = verifyNotInProgress();
         if (statement.code == 0) {
             progress = new ManagerProgress();
@@ -119,6 +122,7 @@ public class LuceneManager extends ManagementLink {
 
     @JavaScriptMethod
     public JSReturnCollection getStatus() {
+        Jenkins.get().getACL().checkPermission(getRequiredPermission());
         JSReturnCollection statement = new JSReturnCollection();
         if (progress != null) {
             statement.progress = progress;

--- a/src/main/resources/org/jenkinsci/plugins/lucene/search/config/SearchBackendConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/lucene/search/config/SearchBackendConfiguration/config.jelly
@@ -11,7 +11,7 @@
                 </f:entry>
             </f:dropdownListBlock>
         </f:dropdownList>
-        <f:entry title="${%Use user security}" field="useSecurity" description="${%Only show search results the user may read to show up. Will slow down searches _considerably_.}">
+        <f:entry title="${%Use user security}" field="useSecurity" description="${%Only show search results the user may read. Will slow down searches _considerably_.}">
             <f:checkbox/>
         </f:entry>
     </f:section>

--- a/src/main/resources/org/jenkinsci/plugins/lucene/search/config/SearchBackendConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/lucene/search/config/SearchBackendConfiguration/config.jelly
@@ -11,5 +11,8 @@
                 </f:entry>
             </f:dropdownListBlock>
         </f:dropdownList>
+        <f:entry title="${%Use user security}" field="useSecurity" description="${%Only show search results the user may read to show up. Will slow down searches _considerably_.}">
+            <f:checkbox/>
+        </f:entry>
     </f:section>
 </j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/lucene/search/databackend/CommonTestCases.java
+++ b/src/test/java/org/jenkinsci/plugins/lucene/search/databackend/CommonTestCases.java
@@ -3,7 +3,6 @@ package org.jenkinsci.plugins.lucene.search.databackend;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -38,7 +37,7 @@ public class CommonTestCases {
             public Throwable call() throws Exception {
                 try {
                     LuceneManager.JSReturnCollection jsonObject = jenkinsSearchBackend.getRebuildStatus(rebuildUrl);
-                    assertEquals(GSON.toJson(jsonObject), 0, jsonObject.code);
+                    assertEquals(GSON.toJson(jsonObject), 0, jsonObject.getCode());
                     return null;
                 } catch (Exception e) {
                     return e;
@@ -49,12 +48,12 @@ public class CommonTestCases {
         assertNull(throwable);
         LuceneManager.JSReturnCollection jsonObject = jenkinsSearchBackend.getRebuildStatus(statusUrl);
         long started = System.currentTimeMillis();
-        while ((jsonObject.running || jsonObject.neverStarted) && started + 10000 > System.currentTimeMillis()) {
+        while ((jsonObject.isRunning() || jsonObject.isNeverStarted()) && started + 10000 > System.currentTimeMillis()) {
             Thread.sleep(1000);
             jsonObject = jenkinsSearchBackend.getRebuildStatus(statusUrl);
         }
-        assertFalse("Test took too long", jsonObject.running || jsonObject.neverStarted);
-        assertEquals(GSON.toJson(jsonObject), 0, jsonObject.code);
+        assertFalse("Test took too long", jsonObject.isRunning() || jsonObject.isNeverStarted());
+        assertEquals(GSON.toJson(jsonObject), 0, jsonObject.getCode());
     }
 
     public static void givenSearchWhenJobsWithBuildsAreExecutedThenTheyShouldBeSearchable(


### PR DESCRIPTION
This PR fixes some issues that prevented `mvn clean install` to run, i.e. blocked HTTP repositories and spotbug findings. It then fixes the published [CVE 2022 36910](https://github.com/advisories/GHSA-m8w5-vwq3-gp8f).

This includes:
- Fix display of `Use Security` option in configuration menus
- Enable `Use Security` by default
- Check Admin capabilities in global configuration section
- Check Admin capabilities for all actions concerning (re-)building the index

This CVE currently blocks publishing of another plugin using this one: https://github.com/jenkins-infra/repository-permissions-updater/issues/2947

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
