### PR TITLE
Escape all templated text in search result screen [CVE-2022-36922]

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/lucene/search/FreeTextSearch/search-results.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/lucene/search/FreeTextSearch/search-results.jelly
@@ -1,5 +1,4 @@
 <?jelly escape-by-default='true'?>
-<?jelly escape-by-default='false'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
     <j:set var="q" value="${request.getParameter('q')}"/>
     <j:new var="h" className="hudson.Functions"/>


### PR DESCRIPTION
In the search results screen the query was displayed without escaping it first. That allowed to inject arbitrary code like javascript. This was possible because the feature of Jelly to escape everything by default was disabled.

This fixes https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-2812.

This is required for this plugin release request: https://github.com/jenkins-infra/repository-permissions-updater/issues/2947

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
