### PR TITLE
Allow to disable Search implementation for users

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextSearchFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextSearchFactory.java
@@ -5,6 +5,9 @@ import hudson.Extension;
 import hudson.search.Search;
 import hudson.search.SearchFactory;
 import hudson.search.SearchableModelObject;
+import jenkins.model.Jenkins;
+
+import org.jenkinsci.plugins.lucene.search.config.SearchBackendConfiguration;
 import org.jenkinsci.plugins.lucene.search.databackend.SearchBackendManager;
 
 @Extension
@@ -12,8 +15,14 @@ public class FreeTextSearchFactory extends SearchFactory {
     @Inject
     SearchBackendManager manager;
 
+    @Inject
+    private transient SearchBackendConfiguration backendConfig;
+
     @Override
     public Search createFor(final SearchableModelObject owner) {
-        return new FreeTextSearch(manager);
+        if (backendConfig.isLuceneSearchEnabled()) {
+            return new FreeTextSearch(manager);
+        }
+        return null;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/config/SearchBackendConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/config/SearchBackendConfiguration.java
@@ -31,17 +31,19 @@ public class SearchBackendConfiguration extends GlobalConfiguration {
 
     private File lucenePath = new File(Jenkins.getInstance().getRootDir(), "luceneIndex");
     private boolean useSecurity = true;
+    private boolean luceneSearchEnabled = true;
 
     @DataBoundConstructor
     public SearchBackendConfiguration(final String lucenePath,
-           boolean useSecurity) {
-        this(new File(lucenePath), useSecurity);
+           boolean useSecurity, boolean luceneSearchEnabled) {
+        this(new File(lucenePath), useSecurity, luceneSearchEnabled);
     }
 
-    public SearchBackendConfiguration(final File lucenePath, boolean useSecurity) {
+    public SearchBackendConfiguration(final File lucenePath, boolean useSecurity, boolean luceneSearchEnabled) {
         load();
         this.lucenePath = lucenePath;
         this.useSecurity = useSecurity;
+        this.luceneSearchEnabled = luceneSearchEnabled;
     }
 
     public SearchBackendConfiguration() {
@@ -108,5 +110,13 @@ public class SearchBackendConfiguration extends GlobalConfiguration {
     public void setUseSecurity(boolean useSecurity) {
         Jenkins.get().getACL().checkPermission(Jenkins.ADMINISTER);
         this.useSecurity = useSecurity;
+    }
+
+    public boolean isLuceneSearchEnabled() {
+        return luceneSearchEnabled;
+    }
+
+    public void setLuceneSearchEnabled(boolean luceneSearchEnabled) {
+        this.luceneSearchEnabled = luceneSearchEnabled;
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/lucene/search/config/SearchBackendConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/lucene/search/config/SearchBackendConfiguration/config.jelly
@@ -14,5 +14,8 @@
         <f:entry title="${%Use user security}" field="useSecurity" description="${%Only show search results the user may read. Will slow down searches _considerably_.}">
             <f:checkbox/>
         </f:entry>
+        <f:entry title="${%Enable Lucene search for users}" field="luceneSearchEnabled" description="${%Sometimes this plugin should only be used by other plugins but not change the way how users search in Jenkins. Thus, this option allows to disable the Lucene search for external users.}">
+            <f:checkbox/>
+        </f:entry>
     </f:section>
 </j:jelly>


### PR DESCRIPTION
This plugin can be used to provide a Lucene index for other plugins that require one. However, in such cases administrators might not want to use the Search implementation this plugin provides.

To allow for such a case, this commit adds an option to disable the Search implementation, while still keeping the Lucene index.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
