### PR TITLE
Support Java 11 and newer Jenkins versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin(platforms: ['linux'])
+buildPlugin(
+    useContainerAgent: true,
+    configurations: [
+        [platform: 'linux', jdk: 11]
+    ])

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	
+
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>4.51</version>
+		<version>4.53</version>
 		<relativePath />
 	</parent>
 
@@ -15,9 +15,8 @@
 	<properties>
 		<changelist>999999-SNAPSHOT</changelist>
 		<gitHubRepo>jenkinsci/lucene-search-plugin</gitHubRepo>
-		<jenkins.version>2.277.4</jenkins.version>
-		<lucene.version>5.3.1</lucene.version>
-		<solr.version>5.3.1</solr.version>
+		<jenkins.version>2.361.4</jenkins.version>
+		<lucene.version>8.11.2</lucene.version>
 		<junit.version>1.9</junit.version>
 	</properties>
 
@@ -58,6 +57,11 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>apache-httpcomponents-client-4-api</artifactId>
+			<version>4.5.13-1.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>junit</artifactId>
 			<version>${junit.version}</version>
 			<optional>false</optional>
@@ -81,11 +85,6 @@
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-highlighter</artifactId>
 			<version>${lucene.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.solr</groupId>
-			<artifactId>solr-solrj</artifactId>
-			<version>${solr.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/CaseSensitiveAnalyzer.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/CaseSensitiveAnalyzer.java
@@ -1,14 +1,10 @@
 package org.jenkinsci.plugins.lucene.search.databackend;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.core.StopFilter;
-import org.apache.lucene.analysis.standard.StandardFilter;
+import org.apache.lucene.analysis.StopFilter;
 import org.apache.lucene.analysis.standard.StandardTokenizer;
-import org.apache.lucene.analysis.util.CharArraySet;
-import org.apache.lucene.analysis.util.StopwordAnalyzerBase;
-
-import java.io.IOException;
-import java.io.Reader;
+import org.apache.lucene.analysis.CharArraySet;
+import org.apache.lucene.analysis.StopwordAnalyzerBase;
 
 public class CaseSensitiveAnalyzer extends StopwordAnalyzerBase {
 
@@ -23,14 +19,10 @@ public class CaseSensitiveAnalyzer extends StopwordAnalyzerBase {
         final StandardTokenizer src = new StandardTokenizer();
         src.setMaxTokenLength(DEFAULT_MAX_TOKEN_LENGTH);
 
-        TokenStream tok = new StandardFilter(src);
-        tok = new StopFilter(tok, this.stopwords);
-        return new TokenStreamComponents(src, tok) {
-            @Override
-            protected void setReader(final Reader reader) throws IOException {
-                src.setMaxTokenLength(DEFAULT_MAX_TOKEN_LENGTH);
-                super.setReader(reader);
-            }
-        };
+        TokenStream tok = new StopFilter(src, this.stopwords);
+        return new TokenStreamComponents(r -> {
+            src.setMaxTokenLength(DEFAULT_MAX_TOKEN_LENGTH);
+            src.setReader(r);
+        }, tok);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
@@ -10,7 +10,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
-import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.*;
@@ -237,7 +237,7 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
                 if (field != null && getIndex(field).numeric) {
                     Long min = getWithDefault(part1, null);
                     Long max = getWithDefault(part2, null);
-                    return NumericRangeQuery.newLongRange(field, min, max, true, true);
+                    return LongPoint.newRangeQuery(field, min, max);
                 } else if (field != null) {
                     return new TermQuery(new Term(field));
                 }
@@ -246,10 +246,8 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
         };
         queryParser.setDefaultOperator(QueryParser.Operator.AND);
         queryParser.setLocale(LOCALE);
-        queryParser.setAnalyzeRangeTerms(true);
         queryParser.setAllowLeadingWildcard(true);
-        queryParser.setLowercaseExpandedTerms(false);
-        queryParser.setMultiTermRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_QUERY_REWRITE);
+        queryParser.setMultiTermRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
         return queryParser;
     }
 
@@ -264,7 +262,7 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
 
                     switch (FIELD_TYPE_MAP.get(field)) {
                         case LONG:
-                            doc.add(new LongField(field.fieldName, ((Number) fieldValue).longValue(), store));
+                            doc.add(new LongPoint(field.fieldName, ((Number) fieldValue).longValue()));
                             break;
                         case STRING:
                             doc.add(new StringField(field.fieldName, fieldValue.toString(), store));


### PR DESCRIPTION
Lucene search did not support new Jenkins versions, since the Lucene version did not support Java 11.

This change update Lucene to 8.11.2, thereby supporting Java 11. It also bumps the Jenkins version to 2.361.4.

BREAKING CHANGE: Existing users will have to delete the existing index and rebuild it, since the update from Lucene 3 to 8 does not provide an upgrade path.

This change also removed the solr-dependency. Since Solr did not support Jetty 10 (will be added with the next release), it would not be supported by newer Jenkins version. Solr-support was anyway not included in the existing releases.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
