### PR TITLE
Fix missing query results

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/lucene/search/Field.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/Field.java
@@ -16,12 +16,7 @@ public enum Field {
 
     PROJECT_NAME("j", Persist.TRUE) {
         public String getValue(final Run<?, ?> build) {
-            StringBuilder builder = new StringBuilder();
-            if (!build.getParent().getParent().getDisplayName().equalsIgnoreCase("jenkins")) {
-                builder.append(build.getParent().getParent().getFullName()).append("/");
-            }
-            builder.append(build.getParent().getName());
-            return builder.toString();
+            return build.getParent().getFullName();
         }
     },
 

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextItemListener.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextItemListener.java
@@ -21,7 +21,7 @@ public class FreeTextItemListener extends ItemListener {
     @Override
     public void onDeleted(Item item) {
         try {
-            searchBackendManager.deleteJob(item.getName());
+            searchBackendManager.deleteJob(item.getFullName());
         } catch (IOException e) {
             logger.error("When deleting the job index: ", e);
         }

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
@@ -57,9 +57,12 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
         FIELD_TYPE_MAP = Collections.unmodifiableMap(types);
     }
 
-    private static final Comparator<Integer> INT_COMPARATOR = new Comparator<Integer>() {
+    private static final Comparator<String> BUILD_COMPARATOR = new Comparator<String>() {
         @Override
-        public int compare(Integer o1, Integer o2) {
+        public int compare(String o1, String o2) {
+            if (o2 == null) {
+                return 1;
+            }
             return o2.compareTo(o1);
         }
     };
@@ -194,11 +197,11 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
             if (hits.length != 0) {
                 lastDoc = hits[hits.length - 1];
             }
-            TreeMap<Integer, Document> docs = new TreeMap<>(INT_COMPARATOR);
+            TreeMap<String, Document> docs = new TreeMap<>(BUILD_COMPARATOR);
 
             for (ScoreDoc hit : hits) {
                 Document doc = searcher.doc(hit.doc);
-                docs.put(Integer.parseInt(doc.get(BUILD_NUMBER.fieldName)), doc);
+                docs.put(doc.get(PROJECT_NAME.fieldName) + doc.get(BUILD_DISPLAY_NAME.fieldName), doc);
             }
 
             for (Document doc : docs.values()) {
@@ -212,7 +215,7 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
 
                 String projectName = doc.get(PROJECT_NAME.fieldName);
                 String buildNumber = doc.get(BUILD_NUMBER.fieldName);
-                String searchName = doc.get(BUILD_DISPLAY_NAME.fieldName);
+                String searchName = doc.get(PROJECT_NAME.fieldName) + doc.get(BUILD_DISPLAY_NAME.fieldName);
 
                 String url = "/job/" + projectName + "/" + buildNumber + "/";
                 luceneSearchResultImpl.add(new FreeTextSearchItemImplementation(searchName,

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
@@ -339,13 +339,10 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
     @Override
     public void deleteJob(String jobName) throws IOException {
         try {
-            Query query = getQueryParser().parse(PROJECT_NAME.fieldName + ":" + QueryParser.escape(jobName));
-            dbWriter.deleteDocuments(query);
+            dbWriter.deleteDocuments(new Term("j", "\"" + jobName + "\""));
             dbWriter.commit();
         } catch (IOException e) {
             LOGGER.error("Could not delete job", e);
-        } catch (ParseException e) {
-            //
         }
     }
 
@@ -367,7 +364,7 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
         }
     }
 
-    static String escapeQuery(String q) {
+    public static String escapeQuery(String q) {
         StringBuilder escapedQuery = new StringBuilder();
         Matcher termMatcher = TERM_PATTERN.matcher(q);
         while (termMatcher.find()) {

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/SearchBackend.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/SearchBackend.java
@@ -70,7 +70,7 @@ public abstract class SearchBackend<T> {
         BurstExecutor<Run> burstExecutor = BurstExecutor.create(new RebuildBuildWorker(progress, overwrite), maxWorkers)
                .andStart();
         if (overwrite) {
-            deleteJob(job.getName());
+            deleteJob(job.getFullName());
         }
         for (Run<?, ?> run : job.getBuilds()) {
             progress.setMax(progress.getMax() + 1);
@@ -150,7 +150,7 @@ public abstract class SearchBackend<T> {
         Progress currentJobProgress = progress.beginJob(job);
         try {
             if (job.getBuilds().isEmpty()) {
-                deleteJob(job.getName());
+                deleteJob(job.getFullName());
             } else {
                 rebuildJob(currentJobProgress, job, maxWorkers, overwrite);
                 progress.assertNoErrors();

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/SearchBackendManager.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/SearchBackendManager.java
@@ -50,7 +50,7 @@ public class SearchBackendManager {
             Iterator<FreeTextSearchItemImplementation> iter = hits.iterator();
             while (iter.hasNext()) {
                 FreeTextSearchItemImplementation searchItem = iter.next();
-                Item item = jenkins.getItem(searchItem.getProjectName());
+                Item item = jenkins.getItemByFullName(searchItem.getProjectName());
                 if (item == null) {
                     iter.remove();
                 }

--- a/src/main/resources/org/jenkinsci/plugins/lucene/search/FreeTextSearch/search-results.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/lucene/search/FreeTextSearch/search-results.jelly
@@ -78,16 +78,6 @@
                 "": put query between double quotes to search for successive words
                 <br/>
             </p>
-            <h3>${%Escaping}</h3>
-            <p>
-                ${%Some chars needs to be escaped}
-                <br/>
-                "error\: something went wrong"
-                <br/>
-                "plug\-in needs to be like this"
-                <br/>
-                "c:\\ also needs to be escaped"
-            </p>
             <h3>${%More information}</h3>
             <p>
                 <a href="http://www.lucenetutorial.com/lucene-query-syntax.html">${%Lucene Query Syntax}</a>

--- a/src/test/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackendUnitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackendUnitTest.java
@@ -1,0 +1,35 @@
+package org.jenkinsci.plugins.lucene.search.databackend;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class LuceneSearchBackendUnitTest {
+    
+    @Test
+    public void escapingQueryWorks() {
+        String[] input = new String[]{
+                "job",
+            "j:job",
+            "job c:job",
+            "folder/job c:job",
+            "j:folder/job",
+            "j:\"this is a job\"",
+            "j:folder/job c:something",
+            "j:folder/job AND c:something"
+        };
+        String[] expected = new String[]{
+                "job",
+                    "j:job",
+                    "job c:job",
+                    "folder\\/job c:job",
+                    "j:folder\\/job",
+                    "j:\\\"this is a job\\\"",
+                    "j:folder\\/job c:something",
+                    "j:folder\\/job AND c:something"
+                };
+        for (int i = 0; i < input.length; i++) {
+            assertEquals(expected[i], LuceneSearchBackend.escapeQuery(input[i]));
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes multiple issues with Lucene queries and should fix #65:

- Queries were not escaped, which led to swallowed Exceptions, if a special char was present in the query. The user would get no result.
- Jobs whose parents were not the Jenkins root were wrongly filtered out by the security filter
- All but one result with the same build number would get lost
- Duplicate job names (when parents were different) led to all but one being deleted from the index

**BREAKING CHANGE**: Note, that the index has to be rebuilt after updating to this version!

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
