### PR TITLE
Add missing luceneSearchPath getter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/lucene/search/config/SearchBackendConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/config/SearchBackendConfiguration.java
@@ -46,6 +46,10 @@ public class SearchBackendConfiguration extends GlobalConfiguration {
     load();
   }
 
+  public File getLucenePath() {
+    return lucenePath;
+  }
+
   public void setLucenePath(final File lucenePath) {
     Jenkins.get().getACL().checkPermission(Jenkins.ADMINISTER);
     this.lucenePath = lucenePath;


### PR DESCRIPTION
This fixes issues when luceneSearchPath setting value isn't displayed in UI. Also, after *any unrelated* jenkins system settings update via UI, luceneSearchPath is set to an empty value. 

This fixes https://issues.jenkins.io/browse/JENKINS-72503

### Testing done

I deployed updated plugin on corporate jenkins, bug was fixed.


