### PR TITLE
Fix potential NullPointerException when build is not found

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
@@ -240,10 +240,13 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
           throw new IllegalStateException("Unknown project type for project name: " + projectName);
         }
         Job job = (Job) jobItem;
-        String url = job.getBuildByNumber(Integer.parseInt(buildNumber)).getUrl();
-        luceneSearchResultImpl.add(
-            new FreeTextSearchItemImplementation(
-                searchName, projectName, bestFragments, url, isShowConsole));
+        Run build = job.getBuildByNumber(Integer.parseInt(buildNumber));
+        if (build != null) {
+          FreeTextSearchItemImplementation itemImpl =
+              new FreeTextSearchItemImplementation(
+                  searchName, projectName, bestFragments, build.getUrl(), isShowConsole);
+          luceneSearchResultImpl.add(itemImpl);
+        }
       }
       reader.close();
     } catch (ParseException e) {


### PR DESCRIPTION
Add null check for build retrieval to prevent NPE when getBuildByNumber returns null.                                                                                                                           This can occur when a build is deleted or the build number is invalid.                                                                                                                                           This prevents crashes when searching for builds that no longer exist.

### Testing done

I tested in on real company jenkins instance. Before this change, the CI server would sotimes crash (probably due to concurent build deletion). After the change, everything works as expected..
