### PR TITLE
Fix interrupt issues, fixes #82

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextSaveableListener.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextSaveableListener.java
@@ -6,12 +6,23 @@ import hudson.model.Run;
 import hudson.model.Saveable;
 import hudson.model.listeners.SaveableListener;
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import javax.inject.Inject;
 import org.apache.log4j.Logger;
 import org.jenkinsci.plugins.lucene.search.databackend.SearchBackendManager;
 
 @Extension
 public class FreeTextSaveableListener extends SaveableListener {
+
+  private static final ExecutorService INDEX_UPDATE_EXECUTOR =
+      Executors.newSingleThreadExecutor(
+          runnable -> {
+            Thread thread = new Thread(runnable, "lucene-search-index-update");
+            thread.setDaemon(true);
+            return thread;
+          });
 
   Logger logger = Logger.getLogger(FreeTextSaveableListener.class);
 
@@ -21,12 +32,22 @@ public class FreeTextSaveableListener extends SaveableListener {
   public void onChange(Saveable o, XmlFile file) {
     if (o instanceof Run) {
       Run run = (Run) o;
-      try {
-        searchBackendManager.removeBuild(run);
-        searchBackendManager.storeBuild(run);
-      } catch (IOException e) {
-        logger.error("update index failed: ", e);
-      }
+      updateIndex(run);
     }
+  }
+
+  private void updateIndex(Run run) {
+    SearchBackendManager manager = searchBackendManager;
+    CompletableFuture.runAsync(
+            () -> {
+              try {
+                manager.removeBuild(run);
+                manager.storeBuild(run);
+              } catch (IOException e) {
+                logger.error("update index failed: ", e);
+              }
+            },
+            INDEX_UPDATE_EXECUTOR)
+        .join();
   }
 }


### PR DESCRIPTION
When a job is aborted, Jenkins sends an interrupt signal to the job threads. This causes the Lucene lock/channel to close. Since Lucene is not interrupt-safe, this fix avoids the issue by moving Lucene work to a separate thread that does not receive the interrupt. The main thread now uses CompletableFuture.join(), which is non-interruptible.

### Testing done
I tested on production jenkins instance, fix works well for a few months.

