### PR TITLE
FreeTextRunListener: Add the store on the build on start

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextRunListener.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextRunListener.java
@@ -18,6 +18,15 @@ public class FreeTextRunListener extends RunListener<Run<?, ?>> {
   @Inject SearchBackendManager searchBackendManager;
 
   @Override
+  public void onStarted(final Run<?, ?> build, @NonNull final TaskListener listener) {
+    try {
+      searchBackendManager.storeBuild(build);
+    } catch (IOException e) {
+      logger.error("When saving the started build index: ", e);
+    }
+  }
+
+  @Override
   public void onCompleted(final Run<?, ?> build, @NonNull final TaskListener listener) {
     try {
       searchBackendManager.storeBuild(build);


### PR DESCRIPTION
We want to be enable to be notified in gerrit if a new build start, so we need to save the build object on start and then save again on end.

### Testing done

Deployed in infrastructure to check if fixes some missed notification to gerrit.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
