### PR TITLE
Fix/crash on project rename

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextRunListener.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextRunListener.java
@@ -18,6 +18,15 @@ public class FreeTextRunListener extends RunListener<Run<?, ?>> {
   @Inject SearchBackendManager searchBackendManager;
 
   @Override
+  public void onStarted(final Run<?, ?> build, @NonNull final TaskListener listener) {
+    try {
+      searchBackendManager.storeBuild(build);
+    } catch (IOException e) {
+      logger.error("When saving the started build index: ", e);
+    }
+  }
+
+  @Override
   public void onCompleted(final Run<?, ?> build, @NonNull final TaskListener listener) {
     try {
       searchBackendManager.storeBuild(build);

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
@@ -246,17 +246,24 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
         String searchName = doc.get(PROJECT_NAME.fieldName) + doc.get(BUILD_DISPLAY_NAME.fieldName);
 
         Item jobItem = jenkins.getItemByFullName(projectName);
+        if (jobItem == null) {
+          LOGGER.debug("Project not found (removed or renamed): " + projectName);
+          continue;
+        }
         if (!(jobItem instanceof Job)) {
-          throw new IllegalStateException("Unknown project type for project name: " + projectName);
+          LOGGER.debug("Unknown project type for project name: " + projectName);
+          continue;
         }
         Job job = (Job) jobItem;
         Run build = job.getBuildByNumber(Integer.parseInt(buildNumber));
-        if (build != null) {
-          FreeTextSearchItemImplementation itemImpl =
-              new FreeTextSearchItemImplementation(
-                  searchName, projectName, bestFragments, build.getUrl(), isShowConsole);
-          luceneSearchResultImpl.add(itemImpl);
+        if (build == null) {
+          LOGGER.debug("Build #" + buildNumber + " not found for project " + projectName + " (possibly removed)");
+          continue;
         }
+        FreeTextSearchItemImplementation itemImpl =
+            new FreeTextSearchItemImplementation(
+                searchName, projectName, bestFragments, build.getUrl(), isShowConsole);
+        luceneSearchResultImpl.add(itemImpl);
       }
       reader.close();
     } catch (ParseException e) {


### PR DESCRIPTION
fix: gracefully skip stale index entries instead of crashing on search
    
When a project or build is removed/renamed after being indexed by
Lucene, getHits() threw an uncaught IllegalStateException, breaking
the entire search request. Replace it with DEBUG-logged continue
guards that silently skip:
- Projects that no longer exist (null from getItemByFullName)
- Items that exist but aren't Jobs
- Build numbers that no longer exist

### Testing done
Deployed and verified

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
