### PR TITLE
Feat/improve performance

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/lucene/search/Field.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/Field.java
@@ -72,7 +72,7 @@ public enum Field {
         }
     };
 
-    private static Map<String, Field> index;
+    private static volatile Map<String, Field> index;
     public final String fieldName;
     public final boolean defaultSearchable;
     public final boolean numeric;
@@ -88,14 +88,20 @@ public enum Field {
     }
 
     public static Field getIndex(String fieldName) {
-        if (index == null) {
-            Map<String, Field> indexReverseLookup = new HashMap<String, Field>();
-            for (Field idx : Field.values()) {
-                indexReverseLookup.put(idx.fieldName, idx);
+        Map<String, Field> idx = index;
+        if (idx == null) {
+            synchronized (Field.class) {
+                idx = index;
+                if (idx == null) {
+                    Map<String, Field> indexReverseLookup = new HashMap<>();
+                    for (Field f : Field.values()) {
+                        indexReverseLookup.put(f.fieldName, f);
+                    }
+                    index = idx = indexReverseLookup;
+                }
             }
-            index = indexReverseLookup;
         }
-        return index.get(fieldName);
+        return idx.get(fieldName);
     }
 
     public abstract Object getValue(final Run<?, ?> build);

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextSaveableListener.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextSaveableListener.java
@@ -38,15 +38,14 @@ public class FreeTextSaveableListener extends SaveableListener {
     private void updateIndex(Run run) {
         SearchBackendManager manager = searchBackendManager;
         CompletableFuture.runAsync(
-                        () -> {
-                            try {
-                                manager.removeBuild(run);
-                                manager.storeBuild(run);
-                            } catch (IOException e) {
-                                logger.error("update index failed: ", e);
-                            }
-                        },
-                        INDEX_UPDATE_EXECUTOR)
-                .join();
+                () -> {
+                    try {
+                        manager.removeBuild(run);
+                        manager.storeBuild(run);
+                    } catch (IOException e) {
+                        logger.error("update index failed: ", e);
+                    }
+                },
+                INDEX_UPDATE_EXECUTOR);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextSaveableListener.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextSaveableListener.java
@@ -46,6 +46,7 @@ public class FreeTextSaveableListener extends SaveableListener {
                         logger.error("update index failed: ", e);
                     }
                 },
-                INDEX_UPDATE_EXECUTOR);
+                INDEX_UPDATE_EXECUTOR)
+                .join();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/BurstExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/BurstExecutor.java
@@ -49,7 +49,7 @@ public class BurstExecutor<T> {
             try {
                 while (!workQueue.isEmpty()) {
                     try {
-                        T poll = workQueue.poll(1000, TimeUnit.MILLISECONDS);
+                        T poll = workQueue.poll(100, TimeUnit.MILLISECONDS);
                         //                        T poll = workQueue.poll();
                         if (poll != null) {
                             worker.run(poll);
@@ -68,22 +68,25 @@ public class BurstExecutor<T> {
         if (!started) {
             throw new IllegalStateException("Not started yet");
         }
+        // Spawn workers to handle remaining work (including work added by
+        // workers themselves during processing).  Do NOT drain the queue
+        // on the calling thread — that would defeat the parallelism.
+        ensureEnoughThreadToFinishJob();
+        // Snapshot active threads under the lock, then join every one
+        // outside the lock to avoid deadlock with removeThread().
+        java.util.ArrayList<WorkerThread> snapshot;
+        synchronized (this) {
+            snapshot = new java.util.ArrayList<>(activeThreads);
+        }
+        for (WorkerThread wt : snapshot) {
+            wt.join();
+        }
+        // A joined thread may have spawned a new one from
+        // ensureEnoughThreadToFinishJob inside its run loop, so
+        // do one final drain pass just in case.
         while (!workQueue.isEmpty()) {
             worker.run(workQueue.poll());
         }
-        ensureEnoughThreadToFinishJob();
-        WorkerThread workerThread;
-        while ((workerThread = getFirstWorkerThread()) != null) {
-            workerThread.join();
-        }
-    }
-
-    private synchronized WorkerThread getFirstWorkerThread() {
-        WorkerThread workerThread = null;
-        if (!activeThreads.isEmpty()) {
-            workerThread = activeThreads.iterator().next();
-        }
-        return workerThread;
     }
 
     public static <T> BurstExecutor<T> create(RunWithArgument<T> worker, int maxThreads) {

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
@@ -338,54 +338,49 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
 
     @Override
     public void storeBuild(final Run<?, ?> run) throws IOException {
-        try {
-            Document doc = new Document();
-            for (Field field : Field.values()) {
-                org.apache.lucene.document.Field.Store store = field.persist ? STORE : DONT_STORE;
-                if (isConsoleField(field) && !collectBuildLogs) {
-                    LOGGER.debug("Skipping console log indexing for field: " + field.fieldName);
-                    doc.add(new TextField(field.fieldName, "", store));
-                } else {
-                    Object fieldValue = field.getValue(run);
-                    if (fieldValue != null) {
-                        switch (FIELD_TYPE_MAP.get(field)) {
-                            case LONG:
-                                doc.add(new LongPoint(field.fieldName, ((Number) fieldValue).longValue()));
-                                break;
-                            case STRING:
-                                doc.add(new StringField(field.fieldName, fieldValue.toString(), store));
-                                break;
-                            case TEXT:
-                                doc.add(new TextField(field.fieldName, fieldValue.toString(), store));
-                                break;
-                            default:
-                                throw new IllegalArgumentException(
-                                        "Don't know how to handle " + FIELD_TYPE_MAP.get(field));
-                        }
+        Document doc = new Document();
+        for (Field field : Field.values()) {
+            org.apache.lucene.document.Field.Store store = field.persist ? STORE : DONT_STORE;
+            if (isConsoleField(field) && !collectBuildLogs) {
+                LOGGER.debug("Skipping console log indexing for field: " + field.fieldName);
+                doc.add(new TextField(field.fieldName, "", store));
+            } else {
+                Object fieldValue = field.getValue(run);
+                if (fieldValue != null) {
+                    switch (FIELD_TYPE_MAP.get(field)) {
+                        case LONG:
+                            doc.add(new LongPoint(field.fieldName, ((Number) fieldValue).longValue()));
+                            break;
+                        case STRING:
+                            doc.add(new StringField(field.fieldName, fieldValue.toString(), store));
+                            break;
+                        case TEXT:
+                            doc.add(new TextField(field.fieldName, fieldValue.toString(), store));
+                            break;
+                        default:
+                            throw new IllegalArgumentException(
+                                    "Don't know how to handle " + FIELD_TYPE_MAP.get(field));
                     }
                 }
             }
-
-            for (FreeTextSearchExtension extension : FreeTextSearchExtension.all()) {
-                try {
-                    Object fieldValue = extension.getTextResult(run);
-                    if (fieldValue != null) {
-                        doc.add(new TextField(
-                                extension.getKeyword(),
-                                extension.getTextResult(run),
-                                (extension.isPersist()) ? STORE : DONT_STORE));
-                    }
-                } catch (Throwable t) {
-                    // We don't want to crash the collection of log from other plugin extensions if we happen
-                    // to add a plugin that crashes while collecting the logs.
-                    LOGGER.warn("CRASH: " + extension.getClass().getName() + ", " + extension.getKeyword() + t);
-                }
-            }
-            dbWriter.addDocument(doc);
-        } finally {
-            dbWriter.commit();
-            searcherManager.maybeRefresh();
         }
+
+        for (FreeTextSearchExtension extension : FreeTextSearchExtension.all()) {
+            try {
+                Object fieldValue = extension.getTextResult(run);
+                if (fieldValue != null) {
+                    doc.add(new TextField(
+                            extension.getKeyword(),
+                            extension.getTextResult(run),
+                            (extension.isPersist()) ? STORE : DONT_STORE));
+                }
+            } catch (Throwable t) {
+                // We don't want to crash the collection of log from other plugin extensions if we happen
+                // to add a plugin that crashes while collecting the logs.
+                LOGGER.warn("CRASH: " + extension.getClass().getName() + ", " + extension.getKeyword() + t);
+            }
+        }
+        dbWriter.addDocument(doc);
     }
 
     public Query getRunQuery(Run<?, ?> run) throws ParseException {
@@ -428,8 +423,6 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
     public void removeBuild(Run<?, ?> run) throws IOException {
         try {
             dbWriter.deleteDocuments(getRunQuery(run));
-            dbWriter.commit();
-            searcherManager.maybeRefresh();
         } catch (ParseException e) {
             LOGGER.warn("removeBuild: " + e);
         }
@@ -444,11 +437,15 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
                 phraseBuilder.add(new Term(PROJECT_NAME.fieldName, parts[i]), i);
             }
             dbWriter.deleteDocuments(phraseBuilder.build());
-            dbWriter.commit();
-            searcherManager.maybeRefresh();
         } catch (IOException e) {
             LOGGER.error("Could not delete job", e);
         }
+    }
+
+    @Override
+    public void commitWrites() throws IOException {
+        dbWriter.commit();
+        searcherManager.maybeRefresh();
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
@@ -83,6 +83,7 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
     private final Analyzer analyzer;
     private Directory index;
     private IndexWriter dbWriter;
+    private SearcherManager searcherManager;
     private final Jenkins jenkins;
     private volatile ScoreDoc lastDoc;
     private final boolean collectBuildLogs;
@@ -123,6 +124,7 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
             dbWriter = new IndexWriter(index, config);
         }
         dbWriter.commit();
+        searcherManager = new SearcherManager(dbWriter, null);
         jenkins = Jenkins.get();
     }
 
@@ -156,6 +158,7 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
     }
 
     public void close() {
+        IOUtils.closeQuietly(searcherManager);
         IOUtils.closeQuietly(dbWriter);
         IOUtils.closeQuietly(index);
     }
@@ -232,9 +235,9 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
     @Override
     public List<FreeTextSearchItemImplementation> getHits(String q, boolean searchNext) {
         List<FreeTextSearchItemImplementation> luceneSearchResultImpl = new ArrayList<>();
+        IndexSearcher searcher = null;
         try {
-            IndexReader reader = DirectoryReader.open(index);
-            IndexSearcher searcher = new IndexSearcher(reader);
+            searcher = searcherManager.acquire();
             Pair<Query, Query, Boolean> fieldQueryPair = parseQuery(q, searcher);
             Query query = fieldQueryPair.first;
             Query highlight = fieldQueryPair.second;
@@ -292,13 +295,20 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
                         searchName, projectName, bestFragments, build.getUrl(), isShowConsole);
                 luceneSearchResultImpl.add(itemImpl);
             }
-            reader.close();
         } catch (ParseException e) {
             //            LOGGER.warn("Search Parsing Error: ", e);
         } catch (IOException e) {
             LOGGER.warn("Search IO Error: ", e);
         } catch (AlreadyClosedException e) {
             LOGGER.warn("IndexReader is closed: ", e);
+        } finally {
+            if (searcher != null) {
+                try {
+                    searcherManager.release(searcher);
+                } catch (IOException e) {
+                    LOGGER.warn("Failed to release searcher: ", e);
+                }
+            }
         }
         return luceneSearchResultImpl;
     }
@@ -374,6 +384,7 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
             dbWriter.addDocument(doc);
         } finally {
             dbWriter.commit();
+            searcherManager.maybeRefresh();
         }
     }
 
@@ -391,17 +402,24 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
 
     @Override
     public boolean findRunIndex(Run<?, ?> run) {
+        IndexSearcher searcher = null;
         try {
             Query query = getRunQuery(run);
-            IndexReader reader = DirectoryReader.open(index);
-            IndexSearcher searcher = new IndexSearcher(reader);
+            searcher = searcherManager.acquire();
             TopDocs docs = searcher.search(query, 1);
-            reader.close();
             return docs.scoreDocs.length > 0;
         } catch (ParseException e) {
             LOGGER.warn("findRunIndex: " + e);
         } catch (IOException e) {
             LOGGER.warn("findRunIndex: " + e);
+        } finally {
+            if (searcher != null) {
+                try {
+                    searcherManager.release(searcher);
+                } catch (IOException e) {
+                    LOGGER.warn("Failed to release searcher in findRunIndex: ", e);
+                }
+            }
         }
         return false;
     }
@@ -411,6 +429,7 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
         try {
             dbWriter.deleteDocuments(getRunQuery(run));
             dbWriter.commit();
+            searcherManager.maybeRefresh();
         } catch (ParseException e) {
             LOGGER.warn("removeBuild: " + e);
         }
@@ -426,6 +445,7 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
             }
             dbWriter.deleteDocuments(phraseBuilder.build());
             dbWriter.commit();
+            searcherManager.maybeRefresh();
         } catch (IOException e) {
             LOGGER.error("Could not delete job", e);
         }
@@ -434,16 +454,24 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
     @Override
     public void cleanAllJob(ManagerProgress progress) {
         Progress currentProgress = progress.beginCleanJob();
+        IndexSearcher searcher = null;
         try {
-            IndexReader reader = DirectoryReader.open(index);
-            currentProgress.setCurrent(reader.numDocs());
+            searcher = searcherManager.acquire();
+            currentProgress.setCurrent(searcher.getIndexReader().numDocs());
             dbWriter.deleteAll();
             dbWriter.commit();
-            reader.close();
+            searcherManager.maybeRefresh();
             progress.setSuccessfullyCompleted();
         } catch (IOException e) {
             progress.completedWithErrors(e);
         } finally {
+            if (searcher != null) {
+                try {
+                    searcherManager.release(searcher);
+                } catch (IOException e) {
+                    LOGGER.warn("Failed to release searcher in cleanAllJob: ", e);
+                }
+            }
             currentProgress.setFinished();
             progress.jobComplete();
         }

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/SearchBackend.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/SearchBackend.java
@@ -62,6 +62,15 @@ public abstract class SearchBackend<T> {
 
     public abstract void deleteJob(String jobName) throws IOException;
 
+    /**
+     * Flushes pending write operations. The default implementation is a no-op;
+     * subclasses that batch writes (e.g. {@link LuceneSearchBackend}) override
+     * it to commit the underlying writer and refresh searchers.
+     */
+    public void commitWrites() throws IOException {
+        // no-op default
+    }
+
     @SuppressWarnings("rawtypes")
     public void rebuildJob(Progress progress, Job<?, ?> job, int maxWorkers, boolean overwrite) throws IOException {
         BurstExecutor<Run> burstExecutor = BurstExecutor.create(new RebuildBuildWorker(progress, overwrite), maxWorkers)
@@ -153,6 +162,7 @@ public abstract class SearchBackend<T> {
                 rebuildJob(currentJobProgress, job, maxWorkers, overwrite);
                 progress.assertNoErrors();
             }
+            commitWrites();
         } finally {
             progress.jobComplete();
         }

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/SearchBackendManager.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/SearchBackendManager.java
@@ -147,6 +147,7 @@ public class SearchBackendManager {
         }
         try {
             backend.removeBuild(run);
+            backend.commitWrites();
         } finally {
             unlockBackend();
         }
@@ -159,6 +160,7 @@ public class SearchBackendManager {
         }
         try {
             backend.deleteJob(jobName);
+            backend.commitWrites();
         } finally {
             unlockBackend();
         }
@@ -174,6 +176,7 @@ public class SearchBackendManager {
             for (Run<?, ?> run : job.getBuilds()) {
                 backend.storeBuild(run);
             }
+            backend.commitWrites();
         } finally {
             unlockBackend();
         }
@@ -186,6 +189,7 @@ public class SearchBackendManager {
         }
         try {
             backend.storeBuild(run);
+            backend.commitWrites();
         } finally {
             unlockBackend();
         }

--- a/src/test/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackendBatchTest.java
+++ b/src/test/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackendBatchTest.java
@@ -1,0 +1,139 @@
+package org.jenkinsci.plugins.lucene.search.databackend;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.Functions;
+import hudson.model.FreeStyleProject;
+import hudson.tasks.BatchFile;
+import hudson.tasks.Builder;
+import hudson.tasks.Shell;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Tests for the batch-commit semantics introduced by commitWrites().
+ *
+ * <p>storeBuild() only buffers documents in the IndexWriter. Only
+ * commitWrites() flushes to disk and refreshes the searcher so that
+ * subsequent getHits() calls see the changes. This enables the rebuild
+ * path to commit once per job instead of once per build.
+ */
+@WithJenkins
+class LuceneSearchBackendBatchTest {
+
+    private JenkinsRule rule;
+    private java.nio.file.Path tempDir;
+
+    @BeforeEach
+    void setUp(JenkinsRule r) throws Exception {
+        rule = r;
+        tempDir = java.nio.file.Files.createTempDirectory("lucene-batch-test-");
+    }
+
+    @AfterEach
+    void tearDown() throws java.io.IOException {
+        FileUtils.deleteDirectory(tempDir.toFile());
+    }
+
+    /**
+     * storeBuild() buffers the document in the IndexWriter. Without
+     * commitWrites(), a concurrent search via getHits() must not see it.
+     */
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void storeBuildWithoutCommitShouldNotBeSearchable() throws Exception {
+        LuceneSearchBackend backend = createBackend();
+
+        FreeStyleProject project = rule.createFreeStyleProject("batch-project");
+        project.getBuildersList().add(buildScript("UNIQUE_BATCH_WORD"));
+        rule.buildAndAssertSuccess(project);
+
+        backend.storeBuild(project.getLastBuild());
+
+        var hits = backend.getHits("UNIQUE_BATCH_WORD", false);
+        assertEquals(0, hits.size(),
+                "Data must not be searchable before commitWrites()");
+        assertDoesNotThrow(backend::close);
+    }
+
+    /**
+     * storeBuild() + commitWrites() must make data searchable and
+     * durable across close/reopen.
+     */
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void commitWritesShouldMakeStoreBuildVisibleAndDurable() throws Exception {
+        LuceneSearchBackend backend = createBackend();
+
+        FreeStyleProject project = rule.createFreeStyleProject("commit-project");
+        project.getBuildersList().add(buildScript("UNIQUE_COMMIT_WORD"));
+        rule.buildAndAssertSuccess(project);
+
+        backend.storeBuild(project.getLastBuild());
+        backend.commitWrites();
+
+        var hits = backend.getHits("UNIQUE_COMMIT_WORD", false);
+        assertTrue(hits.size() > 0, "Data must be searchable after commitWrites()");
+
+        backend.close();
+
+        // Re-open: committed data must survive.
+        LuceneSearchBackend reopened = createBackend();
+        var reopenedHits = reopened.getHits("UNIQUE_COMMIT_WORD", false);
+        assertTrue(reopenedHits.size() > 0, "Committed data must survive close/reopen");
+        reopened.close();
+    }
+
+    /**
+     * Multiple storeBuild() calls batched into one commitWrites() must all
+     * become visible at once — this is the core optimization that lets
+     * rebuildDatabase() commit per-job instead of per-build.
+     */
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void multipleStoreBuildsBatchedInSingleCommitShouldAllBeVisible() throws Exception {
+        LuceneSearchBackend backend = createBackend();
+
+        FreeStyleProject project = rule.createFreeStyleProject("batch-multi");
+        project.getBuildersList().add(buildScript("BATCH_MULTI_WORD"));
+        rule.buildAndAssertSuccess(project);
+        rule.buildAndAssertSuccess(project);
+        rule.buildAndAssertSuccess(project);
+
+        for (var build : project.getBuilds()) {
+            backend.storeBuild(build);
+        }
+        backend.commitWrites();
+
+        var hits = backend.getHits("BATCH_MULTI_WORD", false);
+        assertEquals(3, hits.size(),
+                "All three builds must be searchable after one commitWrites()");
+        backend.close();
+    }
+
+    // ── helpers ──────────────────────────────────────────────────
+
+    private LuceneSearchBackend createBackend() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("lucenePath", tempDir.toFile());
+        config.put("collectBuildLogs", true);
+        return LuceneSearchBackend.create(config);
+    }
+
+    private static Builder buildScript(String word) {
+        return Functions.isWindows()
+                ? new BatchFile("echo " + word + "\n")
+                : new Shell("echo " + word + "\n");
+    }
+}


### PR DESCRIPTION
# Thread safety and performance optimizations

---

## 🟡 Correctness fixes

**BurstExecutor.waitForCompletion()** — The main thread was draining the work queue serially (defeating the worker pool), then only `join()`-ing one thread from a `HashSet` instead of all workers. Now snapshots active threads under the lock and joins every one. Reduced idle poll timeout from 1000ms to 100ms.

**Field.getIndex()** — The lazy-initialized lookup map was not thread-safe: two concurrent threads could both see `null` and build the map twice. Fixed with `volatile` + synchronized double-checked locking.

---

## 🟡 Performance: SearcherManager caching

**Before:** Every `getHits()`, `findRunIndex()`, and `cleanAllJob()` call opened a fresh `DirectoryReader` (`DirectoryReader.open(index)` + `reader.close()`). This reads the segments file and opens all segment readers — expensive for a search plugin called on every Jenkins page load.

**After:** A `SearcherManager` is created once in the constructor and passed to the `IndexWriter`. `searcherManager.acquire()` returns a cached `IndexSearcher`, `searcherManager.release()` returns it. The manager reopens automatically when the index changes. After every write, `searcherManager.maybeRefresh()` ensures the next search sees the latest data.

---

## 🟡 Performance: Batch commits during rebuild

**Before:** `storeBuild()` committed (`dbWriter.commit()`) after every single build. During `rebuildDatabase()` this meant 30K builds = 30K commits.

**After:** `storeBuild()`, `removeBuild()`, `deleteJob()` only buffer in the `IndexWriter` (no commit). A new `commitWrites()` method flushes + refreshes. `rebuildSingleJob()` calls `commitWrites()` once per job — 30K builds across 100 jobs = 100 commits instead of 30K. Incremental single-build operations go through `SearchBackendManager`, which calls `commitWrites()` after each operation to preserve immediate-commit semantics.

---

## Files changed

| File | Change |
|------|--------|
| `Field.java` | volatile + double-checked locking for lazy lookup map |
| `BurstExecutor.java` | Join all workers, remove dead code, reduce poll timeout |
| `LuceneSearchBackend.java` | SearcherManager, batch commit (commitWrites), remove per-op commits |
| `SearchBackend.java` | Add `commitWrites()` (no-op default), call it from `rebuildSingleJob()` |
| `SearchBackendManager.java` | commitWrites() after each incremental write |
| `FreeTextSaveableListener.java` | Restore .join() — removing it caused a removeBuild/storeBuild race |
| `LuceneSearchBackendBatchTest.java` | 3 tests: uncommitted data invisible, commitWrites visible+durable, batch commit |

---

## Testing

```bash
mvn test
```

All 20 tests pass: 17 existing + 3 new batch commit tests.

Deploy in infrastructure and verify normal  operations

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
