### PR TITLE
Feat/fix index update

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextItemListener.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextItemListener.java
@@ -20,8 +20,10 @@ public class FreeTextItemListener extends ItemListener {
 
     @Override
     public void onDeleted(Item item) {
+        logger.debug("onDeleted: item=" + item.getFullName());
         try {
             searchBackendManager.deleteJob(item.getFullName());
+            logger.debug("onDeleted: deleted OK item=" + item.getFullName());
         } catch (IOException e) {
             logger.error("When deleting the job index: ", e);
         }
@@ -32,6 +34,7 @@ public class FreeTextItemListener extends ItemListener {
         if (!(item instanceof Job)) {
             return;
         }
+        logger.debug("onRenamed: old=" + oldName + " new=" + newName + " item=" + item.getFullName());
         try {
             String oldFullName;
             if (item.getParent() instanceof Jenkins) {
@@ -40,6 +43,7 @@ public class FreeTextItemListener extends ItemListener {
                 oldFullName = item.getParent().getFullName() + "/" + oldName;
             }
             searchBackendManager.renameJob(oldFullName, (Job<?, ?>) item);
+            logger.debug("onRenamed: renamed OK old=" + oldFullName + " new=" + item.getFullName());
         } catch (IOException e) {
             logger.error("When renaming the job index: ", e);
         }
@@ -50,8 +54,10 @@ public class FreeTextItemListener extends ItemListener {
         if (!(item instanceof Job)) {
             return;
         }
+        logger.debug("onLocationChanged: old=" + oldFullName + " new=" + newFullName + " item=" + item.getFullName());
         try {
             searchBackendManager.renameJob(oldFullName, (Job<?, ?>) item);
+            logger.debug("onLocationChanged: moved OK old=" + oldFullName + " new=" + newFullName);
         } catch (IOException e) {
             logger.error("When moving the job index: ", e);
         }

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextRunListener.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextRunListener.java
@@ -20,8 +20,13 @@ public class FreeTextRunListener extends RunListener<Run<?, ?>> {
 
     @Override
     public void onStarted(final Run<?, ?> build, @NonNull final TaskListener listener) {
+        logger.debug("onStarted: storing build=" + build.getFullDisplayName()
+                + " number=" + build.getNumber()
+                + " isBuilding=" + build.isBuilding()
+                + " isLogUpdated=" + build.isLogUpdated());
         try {
             searchBackendManager.storeBuild(build);
+            logger.debug("onStarted: stored OK build=" + build.getFullDisplayName());
         } catch (IOException e) {
             logger.error("When saving the started build index: ", e);
         }
@@ -29,8 +34,13 @@ public class FreeTextRunListener extends RunListener<Run<?, ?>> {
 
     @Override
     public void onCompleted(final Run<?, ?> build, @NonNull final TaskListener listener) {
+        logger.debug("onCompleted: storing build=" + build.getFullDisplayName()
+                + " number=" + build.getNumber()
+                + " result=" + build.getResult()
+                + " duration=" + build.getDuration());
         try {
             searchBackendManager.storeBuild(build);
+            logger.debug("onCompleted: stored OK build=" + build.getFullDisplayName());
         } catch (IOException e) {
             logger.error("When saving the finished build index: ", e);
         }
@@ -38,8 +48,11 @@ public class FreeTextRunListener extends RunListener<Run<?, ?>> {
 
     @Override
     public void onDeleted(final Run<?, ?> build) {
+        logger.debug("onDeleted: removing build=" + build.getFullDisplayName()
+                + " number=" + build.getNumber());
         try {
             searchBackendManager.removeBuild(build);
+            logger.debug("onDeleted: removed OK build=" + build.getFullDisplayName());
         } catch (IOException e) {
             logger.error("When removing the deleted build index: ", e);
         }

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextSaveableListener.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextSaveableListener.java
@@ -45,8 +45,9 @@ public class FreeTextSaveableListener extends SaveableListener {
         CompletableFuture.runAsync(
                 () -> {
                     try {
-                        logger.debug("updateIndex: remove+store build=" + run.getFullDisplayName());
-                        manager.removeBuild(run);
+                        // storeBuild uses updateDocument (atomic upsert) — no need
+                        // to remove first; the build never disappears from searches.
+                        logger.debug("updateIndex: upsert build=" + run.getFullDisplayName());
                         manager.storeBuild(run);
                         logger.debug("updateIndex: done build=" + run.getFullDisplayName());
                     } catch (IOException e) {

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextSaveableListener.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextSaveableListener.java
@@ -30,7 +30,12 @@ public class FreeTextSaveableListener extends SaveableListener {
     @Override
     public void onChange(Saveable o, XmlFile file) {
         if (o instanceof Run) {
-            Run run = (Run) o;
+            Run<?, ?> run = (Run<?, ?>) o;
+            logger.debug("onChange: build=" + run.getFullDisplayName()
+                    + " number=" + run.getNumber()
+                    + " isBuilding=" + run.isBuilding()
+                    + " isLogUpdated=" + run.isLogUpdated()
+                    + " file=" + (file != null ? file.getFile() : "null"));
             updateIndex(run);
         }
     }
@@ -40,8 +45,10 @@ public class FreeTextSaveableListener extends SaveableListener {
         CompletableFuture.runAsync(
                 () -> {
                     try {
+                        logger.debug("updateIndex: remove+store build=" + run.getFullDisplayName());
                         manager.removeBuild(run);
                         manager.storeBuild(run);
+                        logger.debug("updateIndex: done build=" + run.getFullDisplayName());
                     } catch (IOException e) {
                         logger.error("update index failed: ", e);
                     }

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextSaveableListener.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/FreeTextSaveableListener.java
@@ -31,6 +31,17 @@ public class FreeTextSaveableListener extends SaveableListener {
     public void onChange(Saveable o, XmlFile file) {
         if (o instanceof Run) {
             Run<?, ?> run = (Run<?, ?>) o;
+            // onStarted already indexed this build, and onCompleted will do the
+            // final index. When we're NOT indexing console logs, nothing in the
+            // searchable document changes between start and finish — project
+            // name, build number, parameters, and display name are all fixed at
+            // build start. Skipping mid-build saves eliminates the constant index
+            // churn we'd otherwise cause every 1-2 seconds.
+            if (run.isBuilding() && !searchBackendManager.isCollectingBuildLogs()) {
+                logger.debug("onChange: skipping still-building " + run.getFullDisplayName()
+                        + " (no indexed fields change)");
+                return;
+            }
             logger.debug("onChange: build=" + run.getFullDisplayName()
                     + " number=" + run.getNumber()
                     + " isBuilding=" + run.isBuilding()

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
@@ -338,6 +338,9 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
 
     @Override
     public void storeBuild(final Run<?, ?> run) throws IOException {
+        LOGGER.debug("LuceneBackend.storeBuild: build=" + run.getFullDisplayName()
+                + " number=" + run.getNumber()
+                + " project=" + run.getParent().getFullName());
         Document doc = new Document();
         for (Field field : Field.values()) {
             org.apache.lucene.document.Field.Store store = field.persist ? STORE : DONT_STORE;
@@ -381,6 +384,8 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
             }
         }
         dbWriter.addDocument(doc);
+        LOGGER.debug("LuceneBackend.storeBuild: document added to writer for build="
+                + run.getFullDisplayName() + " (commitWrites will flush)");
     }
 
     public Query getRunQuery(Run<?, ?> run) throws ParseException {
@@ -421,6 +426,9 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
 
     @Override
     public void removeBuild(Run<?, ?> run) throws IOException {
+        LOGGER.debug("LuceneBackend.removeBuild: build=" + run.getFullDisplayName()
+                + " number=" + run.getNumber()
+                + " project=" + run.getParent().getFullName());
         try {
             dbWriter.deleteDocuments(getRunQuery(run));
         } catch (ParseException e) {
@@ -430,6 +438,7 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
 
     @Override
     public void deleteJob(String jobName) throws IOException {
+        LOGGER.debug("LuceneBackend.deleteJob: job=" + jobName);
         try {
             String[] parts = jobName.split("/");
             PhraseQuery.Builder phraseBuilder = new PhraseQuery.Builder();
@@ -444,8 +453,10 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
 
     @Override
     public void commitWrites() throws IOException {
+        LOGGER.debug("LuceneBackend.commitWrites: committing and refreshing searcher");
         dbWriter.commit();
         searcherManager.maybeRefresh();
+        LOGGER.debug("LuceneBackend.commitWrites: done");
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/LuceneSearchBackend.java
@@ -80,6 +80,13 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
 
     private static final int MAX_HITS_PER_PAGE = 100;
 
+    /**
+     * A synthetic stored field that uniquely identifies a build document.
+     * Used with {@link IndexWriter#updateDocument(Term, Iterable)} to make
+     * storeBuild an atomic upsert — no gap between remove and add.
+     */
+    static final String UNIQUE_KEY_FIELD = "_unique_key";
+
     private final Analyzer analyzer;
     private Directory index;
     private IndexWriter dbWriter;
@@ -87,6 +94,16 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
     private final Jenkins jenkins;
     private volatile ScoreDoc lastDoc;
     private final boolean collectBuildLogs;
+
+    /** Builds the unique key for a Run: "projectFullName#buildNumber". */
+    private static String uniqueKeyFor(Run<?, ?> run) {
+        return run.getParent().getFullName() + "#" + run.getNumber();
+    }
+
+    /** Builds the unique {@link Term} for a Run, used for upsert/deletion. */
+    static Term uniqueTermFor(Run<?, ?> run) {
+        return new Term(UNIQUE_KEY_FIELD, uniqueKeyFor(run));
+    }
 
     public LuceneSearchBackend(final File indexPath, final boolean useBuildLogs) throws IOException {
         analyzer = new CaseSensitiveAnalyzer();
@@ -342,6 +359,9 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
                 + " number=" + run.getNumber()
                 + " project=" + run.getParent().getFullName());
         Document doc = new Document();
+        // Unique key for atomic upsert — updateDocument deletes any
+        // existing doc with the same term before adding this one.
+        doc.add(new StringField(UNIQUE_KEY_FIELD, uniqueKeyFor(run), STORE));
         for (Field field : Field.values()) {
             org.apache.lucene.document.Field.Store store = field.persist ? STORE : DONT_STORE;
             if (isConsoleField(field) && !collectBuildLogs) {
@@ -383,8 +403,10 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
                 LOGGER.warn("CRASH: " + extension.getClass().getName() + ", " + extension.getKeyword() + t);
             }
         }
-        dbWriter.addDocument(doc);
-        LOGGER.debug("LuceneBackend.storeBuild: document added to writer for build="
+        // Atomic upsert: delete any existing doc for this build, then add.
+        // No gap between remove and add — the build never disappears from searches.
+        dbWriter.updateDocument(uniqueTermFor(run), doc);
+        LOGGER.debug("LuceneBackend.storeBuild: document upserted (updateDocument) for build="
                 + run.getFullDisplayName() + " (commitWrites will flush)");
     }
 
@@ -404,12 +426,11 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
     public boolean findRunIndex(Run<?, ?> run) {
         IndexSearcher searcher = null;
         try {
-            Query query = getRunQuery(run);
+            Term term = uniqueTermFor(run);
+            Query query = new TermQuery(term);
             searcher = searcherManager.acquire();
             TopDocs docs = searcher.search(query, 1);
             return docs.scoreDocs.length > 0;
-        } catch (ParseException e) {
-            LOGGER.warn("findRunIndex: " + e);
         } catch (IOException e) {
             LOGGER.warn("findRunIndex: " + e);
         } finally {
@@ -429,11 +450,9 @@ public class LuceneSearchBackend extends SearchBackend<Document> {
         LOGGER.debug("LuceneBackend.removeBuild: build=" + run.getFullDisplayName()
                 + " number=" + run.getNumber()
                 + " project=" + run.getParent().getFullName());
-        try {
-            dbWriter.deleteDocuments(getRunQuery(run));
-        } catch (ParseException e) {
-            LOGGER.warn("removeBuild: " + e);
-        }
+        Term term = uniqueTermFor(run);
+        LOGGER.debug("LuceneBackend.removeBuild: term=" + term);
+        dbWriter.deleteDocuments(term);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/SearchBackendManager.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/SearchBackendManager.java
@@ -141,26 +141,34 @@ public class SearchBackendManager {
     }
 
     public void removeBuild(Run<?, ?> run) throws IOException {
+        LOG.debug("removeBuild: build=" + run.getFullDisplayName());
         SearchBackend<?> backend = lockBackend("remove build " + run.getFullDisplayName());
         if (backend == null) {
+            LOG.debug("removeBuild: backend is null, SKIPPING build=" + run.getFullDisplayName());
             return;
         }
         try {
+            boolean existed = backend.findRunIndex(run);
+            LOG.debug("removeBuild: existed=" + existed + " build=" + run.getFullDisplayName());
             backend.removeBuild(run);
             backend.commitWrites();
+            LOG.debug("removeBuild: committed OK build=" + run.getFullDisplayName());
         } finally {
             unlockBackend();
         }
     }
 
     public void deleteJob(String jobName) throws IOException {
+        LOG.debug("deleteJob: job=" + jobName);
         SearchBackend<?> backend = lockBackend("delete job " + jobName);
         if (backend == null) {
+            LOG.debug("deleteJob: backend is null, SKIPPING job=" + jobName);
             return;
         }
         try {
             backend.deleteJob(jobName);
             backend.commitWrites();
+            LOG.debug("deleteJob: committed OK job=" + jobName);
         } finally {
             unlockBackend();
         }
@@ -183,13 +191,22 @@ public class SearchBackendManager {
     }
 
     public void storeBuild(Run<?, ?> run) throws IOException {
+        LOG.debug("storeBuild: build=" + run.getFullDisplayName()
+                + " number=" + run.getNumber()
+                + " isBuilding=" + run.isBuilding()
+                + " isLogUpdated=" + run.isLogUpdated()
+                + " result=" + run.getResult());
         SearchBackend<?> backend = lockBackend("store build " + run.getFullDisplayName());
         if (backend == null) {
+            LOG.debug("storeBuild: backend is null, SKIPPING build=" + run.getFullDisplayName());
             return;
         }
         try {
+            boolean existed = backend.findRunIndex(run);
+            LOG.debug("storeBuild: existed=" + existed + " build=" + run.getFullDisplayName());
             backend.storeBuild(run);
             backend.commitWrites();
+            LOG.debug("storeBuild: committed OK build=" + run.getFullDisplayName());
         } finally {
             unlockBackend();
         }

--- a/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/SearchBackendManager.java
+++ b/src/main/java/org/jenkinsci/plugins/lucene/search/databackend/SearchBackendManager.java
@@ -190,6 +190,15 @@ public class SearchBackendManager {
         }
     }
 
+    /**
+     * Returns true when the backend indexes console logs. When false,
+     * onChange saves during a running build can be skipped — no indexed
+     * field changes between onStarted and onCompleted.
+     */
+    public boolean isCollectingBuildLogs() {
+        return backendConfig.isCollectBuildLogs();
+    }
+
     public void storeBuild(Run<?, ?> run) throws IOException {
         LOG.debug("storeBuild: build=" + run.getFullDisplayName()
                 + " number=" + run.getNumber()


### PR DESCRIPTION
## Summary

Fixes a bug where running builds disappeared from search results, and eliminates wasted index churn during builds.

## Problem

Jenkins calls `Run.save()` every 1–2 seconds during a build. Each save triggers `FreeTextSaveableListener.onChange()`, which was calling `removeBuild(run)` → `commitWrites()` → `storeBuild(run)` → `commitWrites()`. Between those two commits the build was invisible to search. On a busy Jenkins, these gaps compound — running builds randomly disappear from search results.

## Root cause analysis (from jenkins.log)

```
thread 264 (lucene-search-index-update):
  removeBuild #105 → storeBuild #105 → removeBuild #105 → storeBuild #105 → ...
thread 264 (lucene-search-index-update):
  removeBuild #123 → storeBuild #123 → removeBuild #123 → storeBuild #123 → ...
```

Thread 264 was cycling `removeBuild`/`storeBuild` as fast as every second, for every running build, endlessly — each cycle leaving a gap where the build wasn't searchable.

## Changes

### Commit 1 — `debug: add lifecycle logging across search index layers`

Add `debug`-level logging to every layer so the full lifecycle of a build through the Lucene index can be traced:

- **FreeTextRunListener** — `onStarted`, `onCompleted`, `onDeleted`
- **FreeTextItemListener** — `onDeleted`, `onRenamed`, `onLocationChanged`
- **FreeTextSaveableListener** — `onChange` (what file triggered it, build state), `updateIndex`
- **SearchBackendManager** — `storeBuild` (existed-before check, backend-null guard), `removeBuild`, `deleteJob`
- **LuceneSearchBackend** — `storeBuild`, `removeBuild`, `deleteJob`, `commitWrites`

Set `org.jenkinsci.plugins.lucene.search` to `DEBUG` in the Jenkins log recorder to enable.

### Commit 2 — `fix: use atomic upsert (updateDocument) via unique key to eliminate index gap`

Replaces `addDocument` + remove-first with `IndexWriter.updateDocument()`, which atomically deletes the old document and inserts the new one in a single operation. The build never disappears from search results between commits.

- Add `_unique_key` field (`projectFullName#buildNumber`) to every document
- `storeBuild` uses `updateDocument(Term, Document)` instead of `addDocument`
- `removeBuild` uses `deleteDocuments(Term)` instead of a parsed `BooleanQuery`
- `findRunIndex` uses `TermQuery` instead of `BooleanQuery`
- `FreeTextSaveableListener.updateIndex` drops the `removeBuild` call — the upsert handles the replace atomically

**Before:** `removeBuild` → commit → [GAP: build missing] → `storeBuild` → commit
**After:** `storeBuild` (`updateDocument`) → commit (atomic, no gap)

### Commit 3 — `perf: skip mid-build onChange re-indexing when console logs are off`

When `collectBuildLogs=false` (the typical configuration), no indexed field changes between `onStarted` and `onCompleted` — project name, build number, parameters, and display name are all fixed at build start. Yet every `build.xml` save was still triggering a full index update.

- Add `SearchBackendManager.isCollectingBuildLogs()` (reads the config directly, no locking)
- Skip the `onChange` update when `run.isBuilding() && !isCollectingBuildLogs()`

## Files changed

| File | Change |
|------|--------|
| `FreeTextItemListener.java` | Debug logging for job delete/rename/move |
| `FreeTextRunListener.java` | Debug logging for build start/complete/delete |
| `FreeTextSaveableListener.java` | Debug logging + skip mid-build onChange when console logs off + drop removeBuild (atomic upsert) |
| `LuceneSearchBackend.java` | `_unique_key` field + `updateDocument` atomic upsert + `Term`-based delete + `TermQuery` lookup + debug logging |
| `SearchBackendManager.java` | `isCollectingBuildLogs()` + debug logging |

## Verification

All 20 tests pass (including `getRunQueryShouldMatchByFullNameNotDisplayName`, which exercises `removeBuild`; and the batch commit / concurrency tests).

```
Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
